### PR TITLE
decrease docker image size from 650 to 72 mb

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 # Ignore secondary tools and cache for creating a docker image
+target
 /target
+.idea
+ci
+docs
+.gitignore
+AUTHORS
+*.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
 [workspace]
 members = [
+    "app",
     "module1",
     "module2",
-    "entrypoint",
 ]
 [profile.release]
 panic = "unwind"
+opt-level = 3
+codegen-units = 16
+incremental = false
+lto = false
+rpath = false
+debug = false
+debug-assertions = false
+overflow-checks = false

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "entrypoint"
+name = "app"
 version = "0.1.0"
 authors = [""]
 edition = "2018"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6,5 +6,5 @@ use std::{thread::sleep, time::Duration};
 fn main() {
     render();
     log();
-    sleep(Duration::from_millis(12000));
+    sleep(Duration::from_millis(5000));
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,12 @@
+build
+docker build --no-cache -t app-image -f Dockerfile .
+run
+docker run -p 8080:8080 --rm --name app app-image
+
+docker images --all
+
+prune
+docker image prune --all
+
+rm image
+docker rmi -f d343aeb50d18

--- a/module1/Cargo.toml
+++ b/module1/Cargo.toml
@@ -20,8 +20,6 @@ documentation = "https://link"
 #build = "build.rs"
 
 
-
-
 [badges]
 
 
@@ -38,12 +36,11 @@ documentation = "https://link"
 
 
 
-
-
-
+# unused
 [profile.release]
 codegen-units = 1
 lto = true
+opt-level = "z"
 
 [profile.dev]
 opt-level = 0
@@ -52,8 +49,5 @@ debug = 1
 codegen-units = 2
 
 #[[bin]]
-
-[lib]
-
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- chef (https://hub.docker.com/r/lukemathwalker/cargo-chef/tags)
- .dockerignore
- profile's Cargo.toml with release options (https://doc.rust-lang.org/cargo/reference/profiles.html)
final docker image 650 mb -> 72 mb